### PR TITLE
Fix for pronoun when converting passive to active voice

### DIFF
--- a/alternative_wordings/models.py
+++ b/alternative_wordings/models.py
@@ -499,7 +499,7 @@ def completion(sentence, prefix):
 if __name__ == "__main__":
     # test for function output
     genAltReturn = generate_alternatives(
-        "The castle was built by her after she stole from them."
+        "The church currently maintains a program of ministry, outreach, and cultural events."
     )
     print("generate_alternatives()")
     print(genAltReturn)


### PR DESCRIPTION
Added extra spacy logic in generate_alternative to convert pronoun prefix to correct pronoun in active form. Previously, the passive pronoun was forced as a prefix leading to issues. Example: "A present was given to me. ", Me needs to be converted to I when converting to active voice (I was given a present). My fix may not work in all cases, but will be better than before.